### PR TITLE
chore: update to drunken toad v1.6.2

### DIFF
--- a/WhoSaidWhatNow/Plugin.cs
+++ b/WhoSaidWhatNow/Plugin.cs
@@ -13,6 +13,7 @@ using Dalamud.Plugin;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Dalamud.DrunkenToad.Extensions;
 using WhoSaidWhatNow.Objects;
 using WhoSaidWhatNow.Services;
 using WhoSaidWhatNow.Utils;
@@ -84,13 +85,13 @@ namespace WhoSaidWhatNow
             try
             {
                 Config = PluginInterface.GetPluginConfig() as Configuration ?? new Configuration();
-                Logger.LogDebug("Config file loaded successfully.");
+                PluginLog.LogDebug("Config file loaded successfully.");
                 Config.Initialize(PluginInterface);
             }
             catch (Exception ex)
             {
-                Logger.LogError("Failed to load config so creating new one.", ex);
-                ChatGuiExtensions.PluginPrint(Plugin.ChatGui, "Error loading config file. New one made.");
+                PluginLog.LogError("Failed to load config so creating new one.", ex);
+                ChatGui.PluginPrint("Error loading config file. New one made.");
                 Config = new Configuration();
                 Config.Save();
                 Config.Initialize(PluginInterface);

--- a/WhoSaidWhatNow/Utils/FileUtils.cs
+++ b/WhoSaidWhatNow/Utils/FileUtils.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
+using Dalamud.DrunkenToad.Extensions;
 using WhoSaidWhatNow.Objects;
 
 namespace WhoSaidWhatNow.Utils

--- a/WhoSaidWhatNow/WhoSaidWhatNow.csproj
+++ b/WhoSaidWhatNow/WhoSaidWhatNow.csproj
@@ -34,7 +34,7 @@
 
   <ItemGroup>
     <PackageReference Include="Dalamud.ContextMenu" Version="1.2.3" />
-    <PackageReference Include="Dalamud.DrunkenToad" Version="1.5.6" />
+    <PackageReference Include="Dalamud.DrunkenToad" Version="1.6.2" />
     <PackageReference Include="DalamudPackager" Version="2.1.11" />
     <PackageReference Include="System.Runtime" Version="4.3.1" />
     <Reference Include="FFXIVClientStructs">

--- a/WhoSaidWhatNow/Windows/ConfigWindow.cs
+++ b/WhoSaidWhatNow/Windows/ConfigWindow.cs
@@ -3,6 +3,8 @@ using Dalamud.Interface.Windowing;
 using ImGuiNET;
 using System;
 using System.Numerics;
+using Dalamud.DrunkenToad.Extensions;
+using Dalamud.Utility;
 using WhoSaidWhatNow.Objects;
 using WhoSaidWhatNow.Utils;
 
@@ -15,7 +17,7 @@ public class ConfigWindow : Window, IDisposable
     private Vector4 newColor = Vector4.One;
     internal const String ID_PANEL_LEFT = "###WhoSaidWhatNowConfig_LeftPanel_Child";
     private readonly Plugin plugin;
-    private readonly string[] worldNames = DataManagerExtensions.WorldNames(Plugin.DataManager);
+    private readonly string[] worldNames = Plugin.DataManager.WorldNames();
 
     public ConfigWindow(Plugin plugin) : base(
         "Who Said What Now - Settings", ImGuiWindowFlags.NoScrollbar | ImGuiWindowFlags.NoScrollWithMouse)
@@ -172,8 +174,7 @@ public class ConfigWindow : Window, IDisposable
         {
             ImGui.BeginChild(ConfigWindow.ID_PANEL_LEFT, new Vector2(0, 0), true);
 
-
-            var parts = IEnumerableExtensions.Split(Plugin.Config.ChannelToggles, (Plugin.Config.ChannelToggles.Count / 2) - 2);
+            var parts = Plugin.Config.ChannelToggles.Split(Plugin.Config.ChannelToggles.Count / 2 - 2);
             //generate checkbox for each chat channel
 
             if (ImGui.BeginTable("channelsEnabled", 3, ImGuiTableFlags.SizingFixedSame))

--- a/WhoSaidWhatNow/Windows/MainWindow.cs
+++ b/WhoSaidWhatNow/Windows/MainWindow.cs
@@ -1,14 +1,13 @@
-using Dalamud.DrunkenToad;
 using Dalamud.Game.ClientState.Objects.SubKinds;
 using Dalamud.Game.ClientState.Objects.Types;
 using Dalamud.Interface.Windowing;
 using Dalamud.Logging;
 using ImGuiNET;
-using LiteDB;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
+using Dalamud.DrunkenToad.Extensions;
 using WhoSaidWhatNow.Objects;
 using WhoSaidWhatNow.Utils;
 

--- a/WhoSaidWhatNow/packages.lock.json
+++ b/WhoSaidWhatNow/packages.lock.json
@@ -10,11 +10,12 @@
       },
       "Dalamud.DrunkenToad": {
         "type": "Direct",
-        "requested": "[1.5.6, )",
-        "resolved": "1.5.6",
-        "contentHash": "AMkUXOWliSg1I6RkmD7tEDxrpRlhnSPF3bmkynDSA4W+Mjf/Ps4+9NiUHhiiplrd+iBgWlRyT7lzs0Zj4NDETA==",
+        "requested": "[1.6.2, )",
+        "resolved": "1.6.2",
+        "contentHash": "NTD+tXBIC2lNjm3AWYf1K3cQi9MKUaZEYQTslQQ0gU5QAIP72BP+Oz7M5DdgA4HBAUH7pTdbM4fmeNNKW0K94g==",
         "dependencies": {
-          "LiteDB": "5.0.11"
+          "Dalamud.Loc": "1.0.4",
+          "Microsoft.Extensions.DependencyInjection": "7.0.0"
         }
       },
       "DalamudPackager": {
@@ -33,10 +34,23 @@
           "Microsoft.NETCore.Targets": "1.1.3"
         }
       },
-      "LiteDB": {
+      "Dalamud.Loc": {
         "type": "Transitive",
-        "resolved": "5.0.11",
-        "contentHash": "6cL4bOmVCUB0gIK+6qIr68HeqjjHZicPDGQjvJ87mIOvkFsEsJWkIps3yoKNeLpHhJQur++yoQ9Q8gxsdos0xQ=="
+        "resolved": "1.0.4",
+        "contentHash": "GOfN2ArN6zZZS18XyADZR3TPGdW47hymh8ghsXNZRo8xIFjtRJJwY7YiP63lpxccfNaILARQWd1MDjGIXHZDOg=="
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "Transitive",
+        "resolved": "7.0.0",
+        "contentHash": "elNeOmkeX3eDVG6pYVeV82p29hr+UKDaBhrZyWvWLw/EVZSYEkZlQdkp0V39k/Xehs2Qa0mvoCvkVj3eQxNQ1Q==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "7.0.0"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "Transitive",
+        "resolved": "7.0.0",
+        "contentHash": "h3j/QfmFN4S0w4C2A6X7arXij/M/OVw3uQHSOFxnND4DyAzO1F9eMX7Eti7lU/OkSthEE0WzRsfT/Dmx86jzCw=="
       },
       "Microsoft.NETCore.Platforms": {
         "type": "Transitive",


### PR DESCRIPTION
Hi there! I recently finished refactoring Dalamud.DrunkenToad as part of an overhaul on one of my own plugins. I wanted to help others with active plugins so I'm raising PRs to fix any upgrade issues. I only tested this by ensuring the plugin could build and load in dev plugins without errors - I'd advise you to do your own checks before pushing this live to users. Hope this helps!